### PR TITLE
feat: structured telemetry pattern signals and concept matcher

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# store all text files with LF line endings in the repo.
+# windows/WSL shared checkouts otherwise produce full-repo CRLF diffs.
+* text=auto eol=lf

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bidux
 Title: Behavioral Insight Design: A Toolkit for Integrating Behavioral Science in UI/UX Design
-Version: 0.4.0
+Version: 0.4.1
 Authors@R:
     person(
         given = "Jeremy",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# bidux 0.4.1
+=============
+
+### IMPROVEMENTS
+
+* **Structured telemetry pattern signals.** New internal `bid_pattern_signal` S3 class and `match_signal_to_concept()` resolver let telemetry detectors emit structured pattern descriptions and map them to BID concepts via a shipped mapping table (`inst/extdata/pattern_concept_mappings.csv`). This is the foundation for extending telemetry coverage beyond the current Stage-1 concepts — see issues #48–#52. The existing prose-based `suggest_theory_from_mappings()` path remains the fallback for hand-authored `bid_notice()` calls, so there is no user-visible behavior change.
+
+* **Line-ending normalization.** Added `.gitattributes` to pin text files to LF in the repository, eliminating repo-wide CRLF diffs caused by Windows/WSL shared checkouts.
+
 # bidux 0.4.0 (2026-02-27)
 ==========================
 

--- a/R/mappings.R
+++ b/R/mappings.R
@@ -210,6 +210,65 @@ suggest_theory_from_mappings <- function(
   )
 }
 
+#' Load pattern-to-concept mappings from external file or defaults
+#'
+#' @description
+#' Loads the structured mapping table used by `match_signal_to_concept()`
+#' to resolve telemetry pattern signals to BID concepts. Mirrors the
+#' conventions of the other `load_*_mappings()` helpers in this file.
+#'
+#' @param custom_mappings Optional custom mappings data frame.
+#' @return Data frame with pattern-to-concept mappings.
+#' @keywords internal
+#' @noRd
+load_pattern_concept_mappings <- function(custom_mappings = NULL) {
+  load_external_data(
+    "pattern_concept_mappings.csv",
+    c(
+      "pattern_type", "subtype", "feature_predicate",
+      "concept", "stage", "confidence"
+    ),
+    get_default_pattern_concept_mappings,
+    custom_mappings
+  )
+}
+
+#' Get default pattern-to-concept mappings (fallback when CSV is absent).
+#'
+#' @return Data frame with the same columns as the shipped CSV.
+#' @keywords internal
+#' @noRd
+get_default_pattern_concept_mappings <- function() {
+  data.frame(
+    pattern_type = c(
+      "unused_input",
+      "delayed_interaction",
+      "error_pattern",
+      "navigation_dropoff",
+      "confusion_pattern"
+    ),
+    subtype = rep(NA_character_, 5),
+    feature_predicate = rep(NA_character_, 5),
+    concept = c(
+      "Cognitive Load Theory",
+      "Cognitive Load Theory",
+      "Hick's Law",
+      "Information Scent",
+      "Cognitive Load Theory"
+    ),
+    stage = rep("Notice", 5),
+    confidence = c(0.7, 0.8, 0.8, 0.8, 0.8),
+    rationale_citation = c(
+      "Sweller (1988)",
+      "Sweller (1988)",
+      "Hick (1952)",
+      "Pirolli & Card (1999)",
+      "Sweller (1988)"
+    ),
+    stringsAsFactors = FALSE
+  )
+}
+
 #' Load concept-bias mappings
 #'
 #' @param custom_mappings Optional custom mappings data frame

--- a/R/telemetry_signal.R
+++ b/R/telemetry_signal.R
@@ -1,0 +1,273 @@
+# structured telemetry pattern signal and concept matcher.
+# a signal carries the measured structural features of a detected pattern,
+# so the concept mapper can key off properties rather than prose keyword regex.
+# this is the foundation for extending telemetry coverage beyond the stage-1
+# concepts currently reachable via suggest_theory_from_mappings().
+
+#' Allowed call symbols inside a feature predicate.
+#' @keywords internal
+#' @noRd
+.pattern_signal_safe_ops <- c(
+  "==", "!=", "<", "<=", ">", ">=",
+  "&&", "||", "&", "|", "!",
+  "+", "-", "*", "/", "^",
+  "%in%",
+  "(", "{", "c"
+)
+
+#' Test whether a value is a scalar atomic.
+#' @keywords internal
+#' @noRd
+.is_scalar_atomic <- function(x) {
+  is.atomic(x) && length(x) == 1L
+}
+
+#' Construct a telemetry pattern signal
+#'
+#' @description
+#' Internal constructor for the structured output of a telemetry pattern
+#' detector. Each signal carries a pattern type, optional subtype, a named
+#' list of measured features (scalar atomics), and optional pre-built
+#' evidence fragments. Downstream, `match_signal_to_concept()` resolves
+#' the signal to a BID concept via the shipped mapping table.
+#'
+#' @param pattern_type Non-empty character scalar (e.g. `"unused_input"`).
+#' @param subtype Optional character scalar (`NA_character_` or `NULL`
+#'   when no subtype applies).
+#' @param features Named list of scalar numeric / integer / logical /
+#'   character values describing the detected pattern.
+#' @param evidence_parts Optional character vector of pre-rendered
+#'   evidence fragments for notice construction.
+#'
+#' @return An object of S3 class `"bid_pattern_signal"`.
+#' @keywords internal
+#' @noRd
+bid_pattern_signal <- function(
+    pattern_type,
+    subtype = NA_character_,
+    features = list(),
+    evidence_parts = character()) {
+  if (
+    !is.character(pattern_type) || length(pattern_type) != 1L ||
+      is.na(pattern_type) || !nzchar(trimws(pattern_type))
+  ) {
+    cli::cli_abort("`pattern_type` must be a non-empty character scalar.")
+  }
+
+  if (is.null(subtype)) {
+    subtype <- NA_character_
+  }
+  if (!is.character(subtype) || length(subtype) != 1L) {
+    cli::cli_abort("`subtype` must be NULL or a character scalar (NA allowed).")
+  }
+
+  if (!is.list(features)) {
+    cli::cli_abort("`features` must be a named list.")
+  }
+  if (length(features) > 0L) {
+    if (is.null(names(features)) || any(!nzchar(names(features)))) {
+      cli::cli_abort("`features` must be a named list (all names non-empty).")
+    }
+    bad <- !vapply(features, .is_scalar_atomic, logical(1L))
+    if (any(bad)) {
+      cli::cli_abort(
+        "All `features` values must be scalar atomic (length-1 numeric, integer, logical, or character)."
+      )
+    }
+  }
+
+  if (!is.character(evidence_parts)) {
+    cli::cli_abort("`evidence_parts` must be a character vector.")
+  }
+
+  structure(
+    list(
+      pattern_type = pattern_type,
+      subtype = subtype,
+      features = features,
+      evidence_parts = evidence_parts
+    ),
+    class = "bid_pattern_signal"
+  )
+}
+
+#' Test whether an object is a `bid_pattern_signal`.
+#' @keywords internal
+#' @noRd
+is_bid_pattern_signal <- function(x) {
+  inherits(x, "bid_pattern_signal")
+}
+
+# ---- safe predicate evaluation ----------------------------------------------
+
+#' Walk an expression and accept only whitelisted calls.
+#'
+#' @description
+#' Returns TRUE if the expression consists only of atomics, names, and
+#' calls to operators in `.pattern_signal_safe_ops`. Namespaced calls
+#' (e.g. `base::system`) parse with a `::` head that is itself a call, so
+#' they are rejected by the "call head must be a name in whitelist" rule.
+#'
+#' @keywords internal
+#' @noRd
+.is_safe_predicate_expr <- function(expr) {
+  if (is.atomic(expr) || is.name(expr)) {
+    return(TRUE)
+  }
+  if (!is.call(expr)) {
+    return(FALSE)
+  }
+  fn <- expr[[1L]]
+  if (!is.name(fn)) {
+    # rejects `::`, `:::`, `(` as a computed function, etc.
+    return(FALSE)
+  }
+  if (!as.character(fn) %in% .pattern_signal_safe_ops) {
+    return(FALSE)
+  }
+  all(vapply(
+    as.list(expr)[-1L],
+    .is_safe_predicate_expr,
+    logical(1L)
+  ))
+}
+
+#' Evaluate a feature predicate against a signal's features.
+#'
+#' @description
+#' NA / empty / whitespace-only predicates evaluate to TRUE so "default"
+#' mapping rows act as catch-alls. Unparseable expressions, predicates
+#' containing non-whitelisted calls, and evaluation errors (including
+#' references to missing features) all yield FALSE.
+#'
+#' @keywords internal
+#' @noRd
+.eval_feature_predicate <- function(predicate, features) {
+  if (
+    is.null(predicate) || length(predicate) != 1L ||
+      is.na(predicate) || !nzchar(trimws(predicate))
+  ) {
+    return(TRUE)
+  }
+
+  parsed <- tryCatch(
+    parse(text = predicate),
+    error = function(e) NULL
+  )
+  if (is.null(parsed) || length(parsed) != 1L) {
+    return(FALSE)
+  }
+
+  expr <- parsed[[1L]]
+  if (!.is_safe_predicate_expr(expr)) {
+    return(FALSE)
+  }
+
+  # bind features in an env whose parent is baseenv() so base operators
+  # (==, &&, %in%, etc.) resolve normally. namespaced calls were rejected
+  # above, so the whitelist is the only escape hatch.
+  env <- list2env(features, parent = baseenv())
+  result <- tryCatch(eval(expr, envir = env), error = function(e) FALSE)
+  isTRUE(result)
+}
+
+# ---- concept matcher --------------------------------------------------------
+
+#' Package-historical fallback returned when no mapping row matches or
+#' all matching rows have unusable confidence values.
+#' @keywords internal
+#' @noRd
+.pattern_signal_fallback <- function() {
+  list(
+    concept = "Cognitive Load Theory",
+    stage = "Notice",
+    confidence = 0.5,
+    rationale = "Sweller (1988); package fallback when no mapping row matches",
+    subtype_matched = NA_character_,
+    is_fallback = TRUE
+  )
+}
+
+#' Resolve a pattern signal to a BID concept
+#'
+#' @description
+#' Walks the pattern-to-concept mapping table, filters to rows whose
+#' `pattern_type` matches the signal, keeps rows whose `feature_predicate`
+#' evaluates to TRUE against the signal's features, then returns the
+#' highest-confidence surviving row. Ties on confidence break on original
+#' row order (stable first-match).
+#'
+#' If no row matches the signal's `pattern_type`, returns the package
+#' fallback (Cognitive Load Theory, confidence 0.5, `is_fallback = TRUE`).
+#'
+#' @param signal A `bid_pattern_signal`.
+#' @param mappings Optional data frame / tibble with columns
+#'   `pattern_type`, `subtype`, `feature_predicate`, `concept`, `stage`,
+#'   `confidence` (and optional `rationale_citation`). When `NULL`, loads
+#'   the shipped mappings via `load_pattern_concept_mappings()`.
+#'
+#' @return A list with elements `concept`, `stage`, `confidence`,
+#'   `rationale`, `subtype_matched`, `is_fallback`.
+#' @keywords internal
+#' @noRd
+match_signal_to_concept <- function(signal, mappings = NULL) {
+  if (!is_bid_pattern_signal(signal)) {
+    cli::cli_abort("`signal` must be a `bid_pattern_signal` object.")
+  }
+
+  if (is.null(mappings)) {
+    mappings <- load_pattern_concept_mappings()
+  }
+
+  pattern_rows <- mappings[
+    !is.na(mappings$pattern_type) &
+      mappings$pattern_type == signal$pattern_type, ,
+    drop = FALSE
+  ]
+  if (nrow(pattern_rows) == 0L) {
+    return(.pattern_signal_fallback())
+  }
+
+  matches <- vapply(
+    seq_len(nrow(pattern_rows)),
+    function(i) {
+      .eval_feature_predicate(
+        pattern_rows$feature_predicate[i],
+        signal$features
+      )
+    },
+    logical(1L)
+  )
+  surviving <- pattern_rows[matches, , drop = FALSE]
+  if (nrow(surviving) == 0L) {
+    return(.pattern_signal_fallback())
+  }
+
+  # coerce confidence so user-supplied mappings with character columns
+  # ("0.8") still rank correctly; non-numeric entries become NA and are
+  # filtered below.
+  conf <- suppressWarnings(as.numeric(surviving$confidence))
+  if (all(is.na(conf))) {
+    # which.max() on all-NA returns integer(0), which would silently yield a
+    # 0-row winner. treat all-NA confidence as "no usable rows".
+    return(.pattern_signal_fallback())
+  }
+
+  # highest confidence wins; which.max returns first index on ties.
+  winner <- surviving[which.max(conf), , drop = FALSE]
+
+  subtype_val <- if ("subtype" %in% names(winner)) winner$subtype else NA
+
+  list(
+    concept = as.character(winner$concept),
+    stage = if ("stage" %in% names(winner)) as.character(winner$stage) else NA_character_,
+    confidence = as.numeric(winner$confidence),
+    rationale = if ("rationale_citation" %in% names(winner)) {
+      as.character(winner$rationale_citation)
+    } else {
+      NA_character_
+    },
+    subtype_matched = if (is.na(subtype_val)) NA_character_ else as.character(subtype_val),
+    is_fallback = FALSE
+  )
+}

--- a/inst/extdata/pattern_concept_mappings.csv
+++ b/inst/extdata/pattern_concept_mappings.csv
@@ -1,0 +1,6 @@
+pattern_type,subtype,feature_predicate,concept,stage,confidence,rationale_citation
+unused_input,,,Cognitive Load Theory,Notice,0.7,Sweller (1988)
+delayed_interaction,,,Cognitive Load Theory,Notice,0.8,Sweller (1988)
+error_pattern,,,Hick's Law,Notice,0.8,Hick (1952)
+navigation_dropoff,,,Information Scent,Notice,0.8,Pirolli & Card (1999)
+confusion_pattern,,,Cognitive Load Theory,Notice,0.8,Sweller (1988)

--- a/tests/testthat/test-telemetry-signal.R
+++ b/tests/testthat/test-telemetry-signal.R
@@ -1,0 +1,541 @@
+# tests for R/telemetry_signal.R and the pattern-concept loader in
+# R/mappings.R. covers: constructor validation, safe-predicate ast
+# whitelist, matcher logic (pattern filtering, predicate evaluation,
+# confidence ranking, fallback), and the loader's custom / default paths.
+
+# ==============================================================================
+# HELPERS
+# ==============================================================================
+
+sample_mappings_df <- function() {
+  data.frame(
+    pattern_type = c(
+      "unused_input",
+      "unused_input",
+      "unused_input",
+      "delayed_interaction"
+    ),
+    subtype = c(
+      "never_touched",
+      "default_kept",
+      NA_character_,
+      NA_character_
+    ),
+    feature_predicate = c(
+      "sessions_used == 0",
+      "sessions_used > 0 && value_variance == 0",
+      NA_character_,
+      NA_character_
+    ),
+    concept = c(
+      "Affordance",
+      "Default Effect",
+      "Cognitive Load Theory",
+      "Cognitive Load Theory"
+    ),
+    stage = c("Structure", "Structure", "Notice", "Notice"),
+    confidence = c(0.85, 0.85, 0.7, 0.8),
+    rationale_citation = c(
+      "Norman (1988)",
+      "Samuelson & Zeckhauser (1988)",
+      "Sweller (1988)",
+      "Sweller (1988)"
+    ),
+    stringsAsFactors = FALSE
+  )
+}
+
+# ==============================================================================
+# CONSTRUCTOR
+# ==============================================================================
+
+test_that("bid_pattern_signal constructs with valid inputs", {
+  s <- bid_pattern_signal(
+    pattern_type = "unused_input",
+    subtype = "never_touched",
+    features = list(sessions_used = 0L, usage_rate = 0),
+    evidence_parts = c("0 of 10 sessions touched input")
+  )
+  expect_s3_class(s, "bid_pattern_signal")
+  expect_identical(s$pattern_type, "unused_input")
+  expect_identical(s$subtype, "never_touched")
+  expect_identical(s$features$sessions_used, 0L)
+  expect_identical(s$evidence_parts, "0 of 10 sessions touched input")
+})
+
+test_that("bid_pattern_signal defaults subtype to NA_character_ and features to empty list", {
+  s <- bid_pattern_signal("unused_input")
+  expect_true(is.na(s$subtype))
+  expect_identical(s$features, list())
+  expect_identical(s$evidence_parts, character())
+})
+
+test_that("bid_pattern_signal coerces NULL subtype to NA", {
+  s <- bid_pattern_signal("unused_input", subtype = NULL)
+  expect_true(is.na(s$subtype))
+})
+
+test_that("bid_pattern_signal rejects invalid pattern_type", {
+  expect_error(bid_pattern_signal(pattern_type = 1), "pattern_type")
+  expect_error(bid_pattern_signal(pattern_type = ""), "pattern_type")
+  expect_error(bid_pattern_signal(pattern_type = "   "), "pattern_type")
+  expect_error(bid_pattern_signal(pattern_type = NA_character_), "pattern_type")
+  expect_error(bid_pattern_signal(pattern_type = c("a", "b")), "pattern_type")
+})
+
+test_that("bid_pattern_signal rejects invalid subtype", {
+  expect_error(bid_pattern_signal("x", subtype = 1), "subtype")
+  expect_error(bid_pattern_signal("x", subtype = c("a", "b")), "subtype")
+})
+
+test_that("bid_pattern_signal rejects non-list features", {
+  expect_error(bid_pattern_signal("x", features = c(1, 2)), "features")
+  expect_error(bid_pattern_signal("x", features = "not a list"), "features")
+})
+
+test_that("bid_pattern_signal requires named features", {
+  expect_error(bid_pattern_signal("x", features = list(1, 2)), "named")
+  expect_error(
+    bid_pattern_signal("x", features = stats::setNames(list(1), "")),
+    "named"
+  )
+})
+
+test_that("bid_pattern_signal rejects non-scalar feature values", {
+  expect_error(
+    bid_pattern_signal("x", features = list(a = 1:3)),
+    "scalar"
+  )
+  expect_error(
+    bid_pattern_signal("x", features = list(a = list(1))),
+    "scalar"
+  )
+})
+
+test_that("bid_pattern_signal rejects non-character evidence_parts", {
+  expect_error(bid_pattern_signal("x", evidence_parts = 1:3), "evidence_parts")
+})
+
+test_that("is_bid_pattern_signal identifies instances and rejects others", {
+  s <- bid_pattern_signal("unused_input")
+  expect_true(is_bid_pattern_signal(s))
+  expect_false(is_bid_pattern_signal(list()))
+  expect_false(is_bid_pattern_signal("foo"))
+  expect_false(is_bid_pattern_signal(NULL))
+})
+
+# ==============================================================================
+# SAFE PREDICATE EVALUATOR
+# ==============================================================================
+
+test_that(".eval_feature_predicate returns TRUE for NA / empty / whitespace predicates", {
+  expect_true(.eval_feature_predicate(NA_character_, list()))
+  expect_true(.eval_feature_predicate("", list()))
+  expect_true(.eval_feature_predicate("   ", list()))
+  expect_true(.eval_feature_predicate(NULL, list()))
+})
+
+test_that(".eval_feature_predicate evaluates comparisons against features", {
+  f <- list(sessions_used = 0, usage_rate = 0.02)
+  expect_true(.eval_feature_predicate("sessions_used == 0", f))
+  expect_false(.eval_feature_predicate("sessions_used > 0", f))
+  expect_true(.eval_feature_predicate("usage_rate < 0.05", f))
+  expect_true(.eval_feature_predicate("usage_rate <= 0.02", f))
+  expect_true(.eval_feature_predicate("sessions_used != 5", f))
+})
+
+test_that(".eval_feature_predicate supports logical operators", {
+  f <- list(a = 1, b = 2)
+  expect_true(.eval_feature_predicate("a == 1 && b == 2", f))
+  expect_false(.eval_feature_predicate("a == 1 && b == 3", f))
+  expect_true(.eval_feature_predicate("a == 1 || b == 99", f))
+  expect_true(.eval_feature_predicate("!(a == 99)", f))
+  expect_true(.eval_feature_predicate("a == 1 & b == 2", f))
+  expect_false(.eval_feature_predicate("a == 99 | b == 99", f))
+})
+
+test_that(".eval_feature_predicate supports arithmetic", {
+  f <- list(x = 10, y = 2)
+  expect_true(.eval_feature_predicate("x / y == 5", f))
+  expect_true(.eval_feature_predicate("x - y * 2 == 6", f))
+  expect_true(.eval_feature_predicate("(x + y) / 2 == 6", f))
+})
+
+test_that(".eval_feature_predicate supports %in% with c()", {
+  f <- list(subtype = "a")
+  expect_true(.eval_feature_predicate('subtype %in% c("a", "b")', f))
+  expect_false(.eval_feature_predicate('subtype %in% c("c", "d")', f))
+})
+
+test_that(".eval_feature_predicate rejects non-whitelisted function calls", {
+  f <- list(x = 1)
+  expect_false(.eval_feature_predicate('system("echo hi")', f))
+  expect_false(.eval_feature_predicate('Sys.getenv("HOME")', f))
+  expect_false(.eval_feature_predicate('file.remove("x")', f))
+  expect_false(.eval_feature_predicate("quote(x)", f))
+  expect_false(.eval_feature_predicate('eval(parse(text = "1+1"))', f))
+  expect_false(.eval_feature_predicate("sum(1, 2)", f))
+})
+
+test_that(".eval_feature_predicate rejects namespaced calls", {
+  f <- list(x = 1)
+  expect_false(.eval_feature_predicate('base::system("ls")', f))
+  expect_false(.eval_feature_predicate("base:::list2env(list())", f))
+  expect_false(.eval_feature_predicate('utils::download.file("x","y")', f))
+})
+
+test_that(".eval_feature_predicate returns FALSE for unparseable input", {
+  expect_false(.eval_feature_predicate("a === b", list(a = 1, b = 2)))
+  expect_false(.eval_feature_predicate("((", list()))
+  expect_false(.eval_feature_predicate("a + ", list(a = 1)))
+})
+
+test_that(".eval_feature_predicate returns FALSE when a referenced feature is missing", {
+  expect_false(.eval_feature_predicate("missing_feature == 1", list(a = 1)))
+})
+
+test_that(".eval_feature_predicate ignores extra features not referenced", {
+  f <- list(a = 1, unused = 99)
+  expect_true(.eval_feature_predicate("a == 1", f))
+})
+
+# ==============================================================================
+# CONCEPT MATCHER
+# ==============================================================================
+
+test_that("match_signal_to_concept picks subtype-specific row when predicate matches", {
+  mappings <- sample_mappings_df()
+  sig <- bid_pattern_signal(
+    pattern_type = "unused_input",
+    subtype = "never_touched",
+    features = list(sessions_used = 0, value_variance = 0)
+  )
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_identical(result$concept, "Affordance")
+  expect_identical(result$stage, "Structure")
+  expect_equal(result$confidence, 0.85)
+  expect_identical(result$subtype_matched, "never_touched")
+  expect_false(result$is_fallback)
+})
+
+test_that("match_signal_to_concept falls through to the default row when subtype predicates fail", {
+  mappings <- sample_mappings_df()
+  sig <- bid_pattern_signal(
+    pattern_type = "unused_input",
+    features = list(sessions_used = 3, value_variance = 0.5)
+  )
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_identical(result$concept, "Cognitive Load Theory")
+  expect_equal(result$confidence, 0.7)
+  expect_true(is.na(result$subtype_matched))
+  expect_false(result$is_fallback)
+})
+
+test_that("match_signal_to_concept only considers rows matching pattern_type", {
+  mappings <- sample_mappings_df()
+  sig <- bid_pattern_signal("delayed_interaction")
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_identical(result$concept, "Cognitive Load Theory")
+  expect_equal(result$confidence, 0.8)
+})
+
+test_that("match_signal_to_concept returns fallback when no row matches pattern_type", {
+  mappings <- sample_mappings_df()
+  sig <- bid_pattern_signal("unknown_pattern")
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_identical(result$concept, "Cognitive Load Theory")
+  expect_equal(result$confidence, 0.5)
+  expect_true(result$is_fallback)
+})
+
+test_that("match_signal_to_concept picks highest confidence on multi-match", {
+  mappings <- data.frame(
+    pattern_type = rep("unused_input", 3L),
+    subtype = c("a", "b", NA_character_),
+    feature_predicate = c("x == 1", "x == 1", NA_character_),
+    concept = c("Low", "High", "Default"),
+    stage = rep("Notice", 3L),
+    confidence = c(0.6, 0.9, 0.5),
+    rationale_citation = c("ref_a", "ref_b", "ref_default"),
+    stringsAsFactors = FALSE
+  )
+  sig <- bid_pattern_signal("unused_input", features = list(x = 1))
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_identical(result$concept, "High")
+  expect_equal(result$confidence, 0.9)
+})
+
+test_that("match_signal_to_concept breaks confidence ties on first-match", {
+  mappings <- data.frame(
+    pattern_type = rep("unused_input", 2L),
+    subtype = c("first", "second"),
+    feature_predicate = c("x == 1", "x == 1"),
+    concept = c("FirstWin", "SecondWin"),
+    stage = rep("Notice", 2L),
+    confidence = c(0.8, 0.8),
+    rationale_citation = c("a", "b"),
+    stringsAsFactors = FALSE
+  )
+  sig <- bid_pattern_signal("unused_input", features = list(x = 1))
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_identical(result$concept, "FirstWin")
+  expect_identical(result$subtype_matched, "first")
+})
+
+test_that("match_signal_to_concept accepts NULL mappings and loads built-in defaults", {
+  sig <- bid_pattern_signal("unused_input")
+  result <- match_signal_to_concept(sig)
+  expect_true(is.character(result$concept))
+  expect_true(result$confidence > 0)
+  expect_false(result$is_fallback)
+})
+
+test_that("match_signal_to_concept validates that input is a bid_pattern_signal", {
+  expect_error(match_signal_to_concept(list(x = 1)), "bid_pattern_signal")
+  expect_error(match_signal_to_concept("foo"), "bid_pattern_signal")
+})
+
+test_that("match_signal_to_concept works with tibble mappings", {
+  skip_if_not_installed("tibble")
+  mappings_tbl <- tibble::as_tibble(sample_mappings_df())
+  sig <- bid_pattern_signal(
+    "unused_input",
+    features = list(sessions_used = 0, value_variance = 0)
+  )
+  result <- match_signal_to_concept(sig, mappings = mappings_tbl)
+  expect_identical(result$concept, "Affordance")
+})
+
+test_that("match_signal_to_concept returns fallback when all matching rows have NA confidence", {
+  mappings <- data.frame(
+    pattern_type = rep("unused_input", 2L),
+    subtype = c("a", NA_character_),
+    feature_predicate = c(NA_character_, NA_character_),
+    concept = c("Bad", "AlsoBad"),
+    stage = rep("Notice", 2L),
+    confidence = c(NA_real_, NA_real_),
+    rationale_citation = c("a", "b"),
+    stringsAsFactors = FALSE
+  )
+  sig <- bid_pattern_signal("unused_input")
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_true(result$is_fallback)
+  expect_identical(result$concept, "Cognitive Load Theory")
+})
+
+test_that("match_signal_to_concept returns fallback for empty mappings", {
+  mappings <- sample_mappings_df()[0, ]
+  sig <- bid_pattern_signal("unused_input")
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_true(result$is_fallback)
+})
+
+test_that("match_signal_to_concept coerces character confidence values", {
+  mappings <- data.frame(
+    pattern_type = rep("unused_input", 2L),
+    subtype = c("low", "high"),
+    feature_predicate = c(NA_character_, NA_character_),
+    concept = c("LowConf", "HighConf"),
+    stage = rep("Notice", 2L),
+    confidence = c("0.5", "0.9"),
+    rationale_citation = c("a", "b"),
+    stringsAsFactors = FALSE
+  )
+  sig <- bid_pattern_signal("unused_input")
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_identical(result$concept, "HighConf")
+})
+
+test_that("match_signal_to_concept treats non-numeric confidence as NA", {
+  mappings <- data.frame(
+    pattern_type = rep("unused_input", 2L),
+    subtype = c("a", "b"),
+    feature_predicate = c(NA_character_, NA_character_),
+    concept = c("Useful", "Garbage"),
+    stage = rep("Notice", 2L),
+    confidence = c("0.7", "not-a-number"),
+    rationale_citation = c("a", "b"),
+    stringsAsFactors = FALSE
+  )
+  sig <- bid_pattern_signal("unused_input")
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_identical(result$concept, "Useful")
+})
+
+test_that("match_signal_to_concept tolerates mappings without a subtype column", {
+  mappings <- data.frame(
+    pattern_type = "unused_input",
+    feature_predicate = NA_character_,
+    concept = "NoSubtype",
+    stage = "Notice",
+    confidence = 0.9,
+    rationale_citation = "ref",
+    stringsAsFactors = FALSE
+  )
+  sig <- bid_pattern_signal("unused_input")
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_identical(result$concept, "NoSubtype")
+  expect_true(is.na(result$subtype_matched))
+})
+
+test_that("match_signal_to_concept handles mappings missing optional columns", {
+  sparse <- data.frame(
+    pattern_type = "unused_input",
+    subtype = NA_character_,
+    feature_predicate = NA_character_,
+    concept = "SparseConcept",
+    confidence = 0.9,
+    stringsAsFactors = FALSE
+  )
+  sig <- bid_pattern_signal("unused_input")
+  result <- match_signal_to_concept(sig, mappings = sparse)
+  expect_identical(result$concept, "SparseConcept")
+  expect_true(is.na(result$stage))
+  expect_true(is.na(result$rationale))
+  expect_false(result$is_fallback)
+})
+
+test_that(".is_safe_predicate_expr rejects backtick-quoted namespaced names", {
+  # reviewer flagged this as a potential bypass; verify it is rejected
+  # because the backticked string is not in the operator whitelist.
+  expr1 <- parse(text = '`base::system`("ls")')[[1L]]
+  expect_false(.is_safe_predicate_expr(expr1))
+  expr2 <- parse(text = '`utils::download.file`("a","b")')[[1L]]
+  expect_false(.is_safe_predicate_expr(expr2))
+})
+
+test_that(".is_safe_predicate_expr rejects exotic expression types (defensive)", {
+  # pairlist is not atomic, not a name, and not a call — triggers the
+  # defensive "not a call" branch.
+  expect_false(.is_safe_predicate_expr(pairlist(1)))
+})
+
+test_that("match_signal_to_concept returns fallback when all predicates evaluate FALSE", {
+  # no default (NA) row, so signal falls off the end of surviving rows.
+  mappings <- data.frame(
+    pattern_type = rep("unused_input", 2L),
+    subtype = c("a", "b"),
+    feature_predicate = c("x == 1", "x == 2"),
+    concept = c("A", "B"),
+    stage = rep("Notice", 2L),
+    confidence = c(0.8, 0.8),
+    rationale_citation = c("r1", "r2"),
+    stringsAsFactors = FALSE
+  )
+  sig <- bid_pattern_signal("unused_input", features = list(x = 99))
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_true(result$is_fallback)
+})
+
+test_that(".is_safe_predicate_expr rejects string-form calls to non-whitelisted heads", {
+  # R's parser normalizes `"=="(a, b)` to `a == b` (normal form), which is
+  # safe. but a string-form call to a non-whitelisted function normalizes
+  # to a regular call whose head name is not in the whitelist, so the
+  # whitelist rejects it.
+  expr <- parse(text = '"system"("ls")')[[1L]]
+  expect_false(.is_safe_predicate_expr(expr))
+})
+
+test_that(".is_safe_predicate_expr rejects computed function heads", {
+  # `get("system")("ls")` has a call (not a name) as the head.
+  expr <- parse(text = 'get("system")("ls")')[[1L]]
+  expect_false(.is_safe_predicate_expr(expr))
+})
+
+test_that(".eval_feature_predicate returns FALSE for multi-statement input", {
+  expect_false(.eval_feature_predicate("1; 2", list()))
+})
+
+test_that(".eval_feature_predicate returns FALSE when result is non-logical", {
+  # eval returns "hello" (character), not TRUE; isTRUE() rejects it.
+  expect_false(.eval_feature_predicate("'hello'", list()))
+  expect_false(.eval_feature_predicate("1 + 1", list()))
+})
+
+test_that("match_signal_to_concept tolerates NA pattern_type rows in mappings", {
+  mappings <- rbind(
+    sample_mappings_df(),
+    data.frame(
+      pattern_type = NA_character_,
+      subtype = NA_character_,
+      feature_predicate = NA_character_,
+      concept = "Garbage",
+      stage = "Notice",
+      confidence = 0.99,
+      rationale_citation = "na row",
+      stringsAsFactors = FALSE
+    )
+  )
+  sig <- bid_pattern_signal("delayed_interaction")
+  result <- match_signal_to_concept(sig, mappings = mappings)
+  expect_identical(result$concept, "Cognitive Load Theory")
+})
+
+# ==============================================================================
+# MAPPING LOADER
+# ==============================================================================
+
+test_that("load_pattern_concept_mappings reads built-in CSV with required columns", {
+  m <- load_pattern_concept_mappings()
+  required <- c(
+    "pattern_type", "subtype", "feature_predicate",
+    "concept", "stage", "confidence"
+  )
+  expect_true(all(required %in% names(m)))
+  expect_gte(nrow(m), 5L)
+})
+
+test_that("load_pattern_concept_mappings built-in seed covers all five current patterns", {
+  m <- load_pattern_concept_mappings()
+  expected <- c(
+    "unused_input", "delayed_interaction", "error_pattern",
+    "navigation_dropoff", "confusion_pattern"
+  )
+  expect_true(all(expected %in% unique(m$pattern_type)))
+})
+
+test_that("load_pattern_concept_mappings accepts custom mappings", {
+  custom <- sample_mappings_df()
+  m <- load_pattern_concept_mappings(custom)
+  expect_equal(nrow(m), nrow(custom))
+  expect_identical(m$concept, custom$concept)
+})
+
+test_that("load_pattern_concept_mappings errors when custom is missing required columns", {
+  bad <- data.frame(pattern_type = "x", concept = "y")
+  expect_error(load_pattern_concept_mappings(bad), "columns")
+})
+
+test_that("get_default_pattern_concept_mappings returns a valid fallback shape", {
+  m <- get_default_pattern_concept_mappings()
+  required <- c(
+    "pattern_type", "subtype", "feature_predicate",
+    "concept", "stage", "confidence"
+  )
+  expect_true(all(required %in% names(m)))
+  expect_equal(nrow(m), 5L)
+  expect_true(all(m$confidence > 0 & m$confidence <= 1))
+})
+
+# ==============================================================================
+# INTEGRATION: signal → mapping → concept round-trip via shipped CSV
+# ==============================================================================
+
+test_that("each existing pattern resolves to a concept via the shipped mapping", {
+  patterns <- c(
+    "unused_input", "delayed_interaction", "error_pattern",
+    "navigation_dropoff", "confusion_pattern"
+  )
+  for (p in patterns) {
+    sig <- bid_pattern_signal(p)
+    result <- match_signal_to_concept(sig)
+    expect_false(
+      result$is_fallback,
+      info = sprintf("pattern %s should have a non-fallback mapping", p)
+    )
+    expect_true(
+      nchar(result$concept) > 0,
+      info = sprintf("pattern %s should resolve to a non-empty concept", p)
+    )
+  }
+})


### PR DESCRIPTION
## Summary

Introduces the internal `bid_pattern_signal` S3 class and `match_signal_to_concept()` resolver, backed by a shipped CSV mapping table (`inst/extdata/pattern_concept_mappings.csv`). Telemetry detectors can now emit structured pattern descriptions and resolve them to BID concepts via measured features rather than prose keyword regex.

This is the **foundation** for extending telemetry concept coverage beyond the current Stage-1 concepts (see the coverage-gap analysis in #48–#52). It is deliberately **additive** — no existing detector is rewired in this PR. The first consumer ships in the stacked PR for #48 (unused-input subtypes).

No user-visible behavior change: the existing prose-based `suggest_theory_from_mappings()` path remains the fallback for hand-authored `bid_notice()` calls.

## What changed

- **New** `R/telemetry_signal.R`
  - `bid_pattern_signal()` constructor with strict input validation
  - `.is_safe_predicate_expr()` AST walker that only accepts calls whose head is a whitelisted operator — rejects `base::system`, backtick-quoted namespaced names, string-form calls to non-whitelisted heads, computed function heads, multi-statement input
  - `.eval_feature_predicate()` evaluates the predicate against a signal's features in a restricted env; malformed / unsafe / erroring predicates uniformly yield `FALSE`
  - `match_signal_to_concept()` filters mappings by `pattern_type`, keeps rows whose predicate matches, returns the highest-confidence survivor (first-match on tie); falls back to Cognitive Load Theory when nothing matches

- **New** `inst/extdata/pattern_concept_mappings.csv` seeding the five existing patterns' default concepts with literature citations (Sweller 1988, Hick 1952, Pirolli & Card 1999).

- **`R/mappings.R`** gains `load_pattern_concept_mappings()` and `get_default_pattern_concept_mappings()`, reusing the existing `load_external_data()` helper — same conventions as the other `load_*_mappings()` functions in the file.

- **`.gitattributes`** pins text files to LF (separate commit). Resolves the repo-wide CRLF diff issue caused by Windows/WSL shared checkouts.

- **`DESCRIPTION`** bumped to 0.4.1.

## Design notes

- **Why an AST whitelist instead of regex?** Predicates come from a shipped CSV (trusted) but `match_signal_to_concept()` also accepts user-supplied `custom_mappings`. Running arbitrary R through `eval()` — even in a restricted env with `baseenv()` as the parent — is exploitable (`base::system` etc. stay reachable). The walker rejects anything whose call head isn't a whitelisted operator; double-defense with the restricted eval.
- **Why keep the prose regex path?** Zero-churn for users who call `bid_notice()` manually with just problem/evidence text. Telemetry detectors get a better path; hand-authored notices keep the old behavior.
- **Fallback confidence is 0.5.** Low enough that any matched row beats it, honest about it being a default.

## Test plan

- [x] `devtools::test()` — **2830 PASS, 0 FAIL**
- [x] `covr::file_coverage()` on the new module — **100% line coverage on `R/telemetry_signal.R`**
- [x] Bypass-attempt tests for the predicate evaluator (namespaced calls, backtick tricks, string-form calls, computed heads, multi-statement input, non-whitelisted functions)
- [x] Matcher edge cases: all-NA confidence, empty mappings, missing optional columns, character-valued confidence, tibble vs. data.frame inputs
- [x] Integration: each of the five shipped pattern types resolves to a non-fallback concept via the CSV

## Follow-ups (stacked)

Implementations for the "must-do" Parts B/C/D from the telemetry review will be stacked against this branch:

- Part B: #48 unused-input subtyping (unlocks Affordance, Default Effect, Processing Fluency)
- Part C: Peak-End pattern (unlocks Peak-End Rule)
- Part D: Entry-page anchoring (unlocks Anchoring Effect)